### PR TITLE
not relevant flag

### DIFF
--- a/src/main/java/org/owasp/webgoat/benchmark/testcode/BenchmarkTest00002.java
+++ b/src/main/java/org/owasp/webgoat/benchmark/testcode/BenchmarkTest00002.java
@@ -42,18 +42,12 @@ public class BenchmarkTest00002 extends HttpServlet {
 
 		javax.servlet.http.Cookie[] cookies = request.getCookies();
 		
-		String param = null;
-		boolean foundit = false;
+		String param = "";
 		if (cookies != null) {
 			for (javax.servlet.http.Cookie cookie : cookies) {
 				if (cookie.getName().equals("foo")) {
 					param = cookie.getValue();
-					foundit = true;
 				}
-			}
-			if (!foundit) {
-				// no cookie found in collection
-				param = "";
 			}
 		} else {
 			// no cookies


### PR DESCRIPTION
There is no need for the flag variable "foundit". since the variable param can be initialised to the defalut value for "cookies not found" at declaration time, whenever the if condition is not met, it will not be changed.

This applies to every class under the testcode package.
