### PR TITLE
Support for the latest version of Find Security Bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 								<plugin>
 									<groupId>com.h3xstream.findsecbugs</groupId>
 									<artifactId>findsecbugs-plugin</artifactId>
-									<version>1.4.0</version>
+									<version>1.4.3</version>
 								</plugin>
 							</plugins>
 						</configuration>

--- a/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
@@ -122,10 +122,10 @@ public class FindbugsReader extends Reader {
 
 			//Injections
 			case "SECSQLIHIB"     : return 564;  // Hibernate Injection, child of SQL Injection
-			case "SECSQLIJDO"     : return 72;
-			case "SECSQLIJPA"     : return 72;
-			case "SECSQLISPRJDBC" : return 72;
-			case "SECSQLIJDBC"    : return 72;
+			case "SECSQLIJDO"     : return 89;
+			case "SECSQLIJPA"     : return 89;
+			case "SECSQLISPRJDBC" : return 89;
+			case "SECSQLIJDBC"    : return 89;
 
 			//LDAP injection
 			case "SECLDAPI" : 	return 90;   // LDAP injection

--- a/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
@@ -113,13 +113,56 @@ public class FindbugsReader extends Reader {
 			return Integer.parseInt( cwe );
 		}
 
+		//This is a fallback mapping for unsupported/old versions of the Find Security Bugs plugin
+		//All important bug patterns have their CWE ID associated in later versions (1.4.3+).
 		switch( cat ) {
-
-			//Padding oracle (no specific CWE .. and not analyze by benchmark)
-			case "PADORA" :      return 00; // servlet cookie - not a vuln
 			//Cookies
-			case "SECCU" :      return 00; // servlet cookie - not a vuln
-			//Others informational elements
+			case "SECIC" : 		return 614;  // insecure cookie use
+			case "SECCU" :      return 00; // servlet cookie
+
+			//Injections
+			case "SECSQLIHIB"     : return 564;  // Hibernate Injection, child of SQL Injection
+			case "SECSQLIJDO"     : return 72;
+			case "SECSQLIJPA"     : return 72;
+			case "SECSQLISPRJDBC" : return 72;
+			case "SECSQLIJDBC"    : return 72;
+
+			//LDAP injection
+			case "SECLDAPI" : 	return 90;   // LDAP injection
+
+			//XPath injection
+			case "SECXPI" : 	return 643;  // XPATH injection
+
+			//Command injection
+			case "SECCI" : 		return 78;   // command injection
+
+			//Weak random
+			case "SECPR" : 		return 330;  // weak random
+
+			//Weak encryption
+			case "SECDU" : 		return 327;  // weak encryption DES
+			case "CIPINT" : 	return 327;	 // weak encryption - cipher with no integrity
+			case "PADORA" : 	return 327;  // padding oracle -- FIXME: probably wrong
+			case "STAIV" : 		return 329;  // static initialization vector for crypto
+
+			//Weak hash
+			case "SECWMD" : 	return 328;  // weak hash
+
+			//Path traversal
+			case "SECPTO" : 	return 22;   // path traversal
+			case "SECPTI" : 	return 22;   // path traversal
+
+			//XSS
+			case "SECXRW" :		return 79;   // XSS
+			case "SECXSS1" :	return 79;   // XSS
+			case "SECXSS2" :	return 79;   // XSS
+
+			//XXE
+			case "SECXXEDOC" :  return 611;  // XXE
+			case "SECXXEREAD" :  return 611;  // XXE
+			case "SECXXESAX" :  return 611;  // XXE
+
+			//Input sources
 			case "SECSP" : 		return 00;	 // servlet parameter - not a vuln
 			case "SECSH" : 		return 00;   // servlet header -- not a vuln
 			case "SECSSQ" : 	return 00;   // servlet query - not a vuln

--- a/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/FindbugsReader.java
@@ -105,35 +105,26 @@ public class FindbugsReader extends Reader {
 			if ( cwe.equals( "23" ) || cwe.equals( "36" ) ) {
 				cwe = "22";
 			}
+			// FSB identify DES/DESede as CWE-326 (Inadequate Encryption Strength) while Benchmark
+			// marked it as CWE-327 (Use of a Broken or Risky Cryptographic Algorithm)
+			else if ( cwe.equals( "326" ) ) {
+				cwe = "327";
+			}
 			return Integer.parseInt( cwe );
 		}
-		
+
 		switch( cat ) {
-		case "SECCU" : 		return 614;  // insecure cookie use
-		case "SECPR" : 		return 330;  // weak random
-		case "SECLDAPI" : 	return 90;   // LDAP injection
-		case "SECPTO" : 	return 22;   // path traversal
-		case "SECPTI" : 	return 22;   // path traversal
-		case "CIPINT" : 	return 327;	 // weak encryption - cipher with no integrity
-		case "PADORA" : 	return 327;  // padding oracle -- FIXME: probably wrong
-		case "SECXPI" : 	return 643;  // XPATH injection
-		case "SECWMD" : 	return 328;  // weak hash
-		case "SECCI" : 		return 78;   // command injection
-		case "SECDU" : 		return 327;  // weak encryption DES
-		case "SECXRW" :		return 79;   // XSS
-		case "SECXSS1" :	return 79;   // XSS
-		case "SECXSS2" :	return 79;   // XSS
-		case "SECXXEDOC" :  return 611;  // XXE - Probably DOM Parser
-		case "SECSQLIHIB" : return 564;  // Hibernate Injection, child of SQL Injection
-		case "SECXXESAX" :  return 611;  // XXE - SAX Parser
-		case "STAIV" : 		return 329;  // static initialization vector for crypto
 
-		case "SECSP" : 		return 00;	 // servlet parameter - not a vuln
-		case "SECSH" : 		return 00;   // servlet header -- not a vuln
-		case "SECSSQ" : 	return 00;   // servlet query - not a vuln
-		
+			//Padding oracle (no specific CWE .. and not analyze by benchmark)
+			case "PADORA" :      return 00; // servlet cookie - not a vuln
+			//Cookies
+			case "SECCU" :      return 00; // servlet cookie - not a vuln
+			//Others informational elements
+			case "SECSP" : 		return 00;	 // servlet parameter - not a vuln
+			case "SECSH" : 		return 00;   // servlet header -- not a vuln
+			case "SECSSQ" : 	return 00;   // servlet query - not a vuln
 
-		default : System.out.println( "Unknown category: " + cat );
+			default : System.out.println( "Unknown category: " + cat );
 		}
 
 		return 0;


### PR DESCRIPTION
Modification to the mapping of FindBugs report parser.
Update the version of Find Security Bugs to the latest release.

We will support the mapping of cwe for Benchmark starting from 1.4.3 (using the cweid annotation in `findbugs.xml`). The sync will be seamless.