### PR TITLE
Fix resource leak in ThingFactory class

### DIFF
--- a/src/main/java/org/owasp/benchmark/helpers/ThingFactory.java
+++ b/src/main/java/org/owasp/benchmark/helpers/ThingFactory.java
@@ -29,8 +29,7 @@ public class ThingFactory {
 		Properties props = new Properties();
 
 		// create a thing using reflection
-		try {
-			InputStream thingproperties = ThingFactory.class.getClassLoader().getResourceAsStream("thing.properties");
+		try (InputStream thingproperties = ThingFactory.class.getClassLoader().getResourceAsStream("thing.properties")) {
 			if (thingproperties == null) {
 				System.out.println("Can't find thing.properties");
 				return new Thing2();


### PR DESCRIPTION
Change ThingFactory class to use try-with-resource statement to manage
the InputStream used to read the file "thing.properties", so that it's
(always) closed.
The issue manifested while exercising, a lot, the OWASP Benchmark
application with OWASP ZAP (for zaproxy/zaproxy#1890).
After many requests sent Benchmark started to fail to fulfil ZAP's
requests. In the output of Tomcat there were many entries like:
[INFO] [talledLocalContainer] Can't find thing.properties
and also:
[INFO] [talledLocalContainer] SEVERE: Socket accept failed
[INFO] [talledLocalContainer] java.io.IOException: Too many open files
the reason why ZAP's requests were no longer fulfilled.
Other attempts to read other files also led to same issue, for example:
...webapps/benchmark/WEB-INF/classes/employees.xml (Too many open files)
Looking at the list of Benchmark's open files it was evident that the
leak was related to read of "thing.properties" file, given how many
open "thing.properties" files there were.
After the change OWASP Benchmark was able to withstand more than twice
the requests without exhibiting the aforementioned issue.