### PR TITLE
No TestCaseResult for PMD returned

### DIFF
--- a/src/main/java/org/owasp/benchmark/score/parsers/PMDReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/PMDReader.java
@@ -80,6 +80,7 @@ public class PMDReader extends Reader {
             
 	        tcr.setCategory( rule );
 	        tcr.setEvidence( rule );
+	        return tcr;
 		}
 					
 		return null;


### PR DESCRIPTION
The method parsePMDItem() was setting up a TestCaseResult object but without returning it.