### PR TITLE
false positive / true negative confusion

### DIFF
--- a/src/main/java/org/owasp/benchmark/score/BenchmarkScore.java
+++ b/src/main/java/org/owasp/benchmark/score/BenchmarkScore.java
@@ -543,8 +543,8 @@ public class BenchmarkScore {
 			else if ( tcr.isReal() && !tcr.isPassed() ) c.fn++; // fn
 			
 			// fake vulnerabilities
-			else if (!tcr.isReal() && tcr.isPassed() ) c.tn++;  // tn
-			else if (!tcr.isReal() && !tcr.isPassed() ) c.fp++; // fp
+			else if (!tcr.isReal() && tcr.isPassed() ) c.fp++;  // fp
+			else if (!tcr.isReal() && !tcr.isPassed() ) c.tn++; // tn
 		}
 		return map;
 	}


### PR DESCRIPTION
If a TestCaseResult is "not" really vulnerable and it was considered vulnerable, then it is a false positive (i.e., if a non-cat is a considered a cat -> false positive).
If a TestCaseResult is "not" really vulnerable and it was "not" considered vulnerable, then it is a true negative (i.e., if a non-cat is a considered a non-cat -> true negative).