### PR TITLE
Add wget to Dockerfile

### DIFF
--- a/VMs/Dockerfile
+++ b/VMs/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -q -y \
      openjdk-8-jdk \
      git \
      maven \
+     wget \
      && apt-get clean
 
 RUN mkdir /owasp


### PR DESCRIPTION
`wget` is used by DAST scanners to check for blind command injection. `nc` and `curl` might also be useful.