### PR TITLE
Add query Unprotected_Cookie to list of isIrrelevant

### DIFF
--- a/src/main/java/org/owasp/benchmark/score/parsers/CheckmarxESReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/CheckmarxESReader.java
@@ -89,7 +89,8 @@ public class CheckmarxESReader extends Reader {
                 name.equals( "Potential_Stored_XSS" ) ||
                 name.equals( "Potential_UTF7_XSS" ) ||
                 name.equals( "Stored_Command_Injection" ) ||
-                name.equals( "CGI_Reflected_XSS_All_Clients" );
+                name.equals( "CGI_Reflected_XSS_All_Clients" ) ||
+                name.equals( "Unprotected_Cookie" );
     }
 
     private int translate(int cwe) {

--- a/src/main/java/org/owasp/benchmark/score/parsers/CheckmarxReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/CheckmarxReader.java
@@ -121,7 +121,8 @@ public class CheckmarxReader extends Reader {
              name.equals( "Potential_Stored_XSS" ) ||
              name.equals( "Potential_UTF7_XSS" ) ||
 			 name.equals( "Stored_Command_Injection" ) ||
-             name.equals( "CGI_Reflected_XSS_All_Clients" )) {
+             name.equals( "CGI_Reflected_XSS_All_Clients" ) ||
+	   name.equals( "Unprotected_Cookie" )) {
             return null;
         }
 


### PR DESCRIPTION
Added query Unprotected_Cookie to list of isIrrelevant method to bypass Benchmark project vulnerability on the following files:

BenchmarkTest00088.html	 
BenchmarkTest00089.html	 
BenchmarkTest01862.html	 
BenchmarkTest01863.html	
