### PR TITLE
Fix Benchmark start-up problems using ESAPI logger with JUL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,7 +922,7 @@ But it might be needed for Java 10, because I get this error, that I don't get w
 		<dependency>
 			<groupId>org.owasp.esapi</groupId>
 			<artifactId>esapi</artifactId>
-			<version>2.2.0.0</version>
+			<version>2.2.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/runBenchmark.sh
+++ b/runBenchmark.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
 chmod 755 src/main/resources/insecureCmd.sh
-mvn clean package cargo:run -Pdeploy
+
+case "$1" in
+-q|--quiet) quiet="-D-Dorg.owasp.esapi.logSpecial.discard=true"; shift  ;;
+*)          quiet=""    ;;
+esac
+mvn ${quiet} clean package cargo:run -Pdeploy

--- a/src/main/resources/ESAPI.properties
+++ b/src/main/resources/ESAPI.properties
@@ -75,8 +75,12 @@ ESAPI.Executor=org.owasp.esapi.reference.DefaultExecutor
 ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
 ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
 # Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
-ESAPI.Logger=org.owasp.esapi.reference.Log4JLogFactory
+#   ESAPI 2.2.0.0 classes
+#ESAPI.Logger=org.owasp.esapi.reference.Log4JLogFactory
 #ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
+#   ESAPI 2.2.1.0 classes
+#ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
+ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
 ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator
 
@@ -363,6 +367,11 @@ Logger.LogServerIP=true
 Logger.LogFileName=ESAPI_logging_file
 # MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
 Logger.MaxLogFileSize=10000000
+# Determines whether ESAPI should log the user info.
+Logger.UserInfo=false
+# Determines whether ESAPI should log the app info.
+Logger.ClientInfo=false
+
 
 
 #===========================================================================

--- a/src/main/resources/ESAPI.properties
+++ b/src/main/resources/ESAPI.properties
@@ -74,12 +74,9 @@ ESAPI.Encryptor=org.owasp.esapi.reference.crypto.JavaEncryptor
 ESAPI.Executor=org.owasp.esapi.reference.DefaultExecutor
 ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
 ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
-# Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
-#   ESAPI 2.2.0.0 classes
-#ESAPI.Logger=org.owasp.esapi.reference.Log4JLogFactory
-#ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
-#   ESAPI 2.2.1.0 classes
+# Log4JFactory requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
 #ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
+# JavaLogFactory requires esapi-java-logging.properties in classpath
 ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
 ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator

--- a/src/main/resources/esapi-java-logging.properties
+++ b/src/main/resources/esapi-java-logging.properties
@@ -1,0 +1,6 @@
+handlers= java.util.logging.ConsoleHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%3$-7s] %5$s %n
+#https://www.logicbig.com/tutorials/core-java-tutorial/logging/customizing-default-format.html


### PR DESCRIPTION
@davewichers - This should fix the problems that you have been encountering with ESAPI logging using JUL (at least during startup), but I think this is ultimately going to be fixed in ESAPI itself. I will discuss an emergency patch (probably ESAPI 2.2.1.1) with @jeremiahjstacey to fix [ESAPI GitHub issue 560](https://github.com/ESAPI/esapi-java-legacy/issues/560) but until that is available, I will document a workaround. 
 