### PR TITLE
Add Fluid Attacks parser

### DIFF
--- a/results/Benchmark_1.2-Fluid-Attacks-v20210416.csv
+++ b/results/Benchmark_1.2-Fluid-Attacks-v20210416.csv
@@ -1,0 +1,1788 @@
+title,what,where,cwe
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00008.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00018.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00024.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00025.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00026.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00027.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00032.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00033.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00034.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00037.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00038.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00039.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00043.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00100.java,80,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00101.java,83,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00102.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00103.java,75,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00106.java,81,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00108.java,90,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00109.java,75,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00111.java,81,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00112.java,72,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00115.java,76,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00192.java,80,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00193.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00194.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00195.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00196.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00198.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00199.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00203.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00204.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00328.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00335.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00337.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00339.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00341.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00342.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00428.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00429.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00431.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00433.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00434.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00435.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00438.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00439.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00441.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00510.java,80,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00512.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00515.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00516.java,78,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00518.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00590.java,76,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00591.java,72,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00593.java,91,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00594.java,75,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00595.java,76,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00596.java,76,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00597.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00598.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00600.java,86,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00603.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00604.java,72,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00606.java,74,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00673.java,63,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00677.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00678.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00679.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00681.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00760.java,63,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00761.java,77,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00762.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00764.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00765.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00767.java,75,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00768.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00769.java,61,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00770.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00771.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00839.java,76,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00840.java,73,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00841.java,86,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00842.java,77,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00843.java,72,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00845.java,73,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00846.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00847.java,78,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00848.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00849.java,78,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00850.java,78,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00996.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00997.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00998.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01000.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01002.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01003.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01004.java,71,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01005.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01006.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01007.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01008.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01009.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01011.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01083.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01084.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01087.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01088.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01090.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01091.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01093.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01094.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01097.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01208.java,61,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01209.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01210.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01211.java,63,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01214.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01221.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01222.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01302.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01304.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01306.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01308.java,51,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01311.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01312.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01313.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01314.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01379.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01381.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01382.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01383.java,60,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01384.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01388.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01390.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01391.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01394.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01395.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01396.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01460.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01462.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01463.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01464.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01465.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01466.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01470.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01471.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01473.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01474.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01475.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01476.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01477.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01552.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01554.java,51,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01557.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01558.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01559.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01560.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01620.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01621.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01623.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01624.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01625.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01626.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01627.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01630.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01631.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01712.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01715.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01716.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01718.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01720.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01721.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01723.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01724.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01725.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01726.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01727.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01728.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01730.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01731.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01733.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01881.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01882.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01883.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01887.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01888.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01889.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01890.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01891.java,69,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01962.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01963.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01964.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01970.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01971.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01972.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02087.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02088.java,62,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02090.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02091.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02092.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02094.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02096.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02099.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02169.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02170.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02171.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02177.java,50,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02178.java,50,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02179.java,51,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02181.java,50,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02182.java,50,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02186.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02187.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02264.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02269.java,61,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02270.java,61,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02272.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02273.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02275.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02277.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02281.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02284.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02286.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02287.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02288.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02354.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02355.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02356.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02357.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02358.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02359.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02360.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02362.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02364.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02369.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02449.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02451.java,52,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02453.java,51,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02454.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02455.java,53,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02528.java,56,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02530.java,57,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02531.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02532.java,58,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02533.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02534.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02535.java,59,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02537.java,54,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02542.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02543.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02545.java,55,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02625.java,67,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02627.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02628.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02630.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02632.java,68,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02635.java,70,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02638.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02641.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02642.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02643.java,64,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02644.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02645.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02646.java,65,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02647.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02649.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02650.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02651.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02653.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02654.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02655.java,66,89
+F001. SQL injection - Java SQL API,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02656.java,66,89
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00006.java,68,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00007.java,61,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00015.java,70,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00017.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00077.java,98,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00091.java,74,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00092.java,93,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00159.java,68,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00172.java,67,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00173.java,66,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00174.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00176.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00293.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00294.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00295.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00302.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00303.java,82,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00304.java,90,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00306.java,70,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00311.java,80,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00407.java,83,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00409.java,92,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00480.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00495.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00496.java,66,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00497.java,81,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00498.java,66,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00499.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00500.java,71,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00567.java,77,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00568.java,88,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00573.java,70,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00574.java,76,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00575.java,84,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00576.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00731.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00740.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00815.java,78,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00816.java,83,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00823.java,81,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00824.java,92,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00825.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00968.java,77,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00979.java,88,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00981.java,88,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00983.java,71,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01064.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01066.java,60,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01190.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01191.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01192.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01194.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01270.java,60,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01285.java,57,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01286.java,69,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01287.java,55,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01288.java,55,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01360.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01361.java,60,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01362.java,76,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01363.java,59,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01430.java,74,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01441.java,83,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01442.java,69,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01446.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01517.java,61,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01531.java,56,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01533.java,53,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01601.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01609.java,61,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01610.java,61,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01673.java,74,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01674.java,74,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01685.java,85,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01689.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01690.java,68,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01691.java,68,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01850.java,77,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01851.java,77,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01852.java,77,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01864.java,75,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01928.java,67,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01929.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01936.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01938.java,76,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01940.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01942.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01944.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02059.java,67,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02070.java,59,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02137.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02146.java,57,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02147.java,57,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02150.java,71,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02151.java,71,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02152.java,71,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02154.java,58,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02155.java,52,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02243.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02244.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02249.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02250.java,62,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02251.java,74,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02333.java,76,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02334.java,76,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02342.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02343.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02344.java,66,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02411.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02412.java,63,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02414.java,61,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02429.java,70,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02430.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02431.java,56,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02432.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02433.java,72,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02496.java,65,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02511.java,58,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02512.java,58,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02514.java,57,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02515.java,57,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02516.java,55,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02517.java,55,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02611.java,85,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02612.java,69,78
+F004. Remote command execution,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02613.java,66,78
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00013.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00014.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00030.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00036.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00041.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00047.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00048.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00049.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00144.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00145.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00146.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00148.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00149.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00150.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00152.java,75,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00153.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00154.java,75,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00155.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00156.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00157.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00276.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00279.java,68,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00280.java,77,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00284.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00287.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00290.java,59,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00291.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00292.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00301.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00375.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00376.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00378.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00380.java,70,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00382.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00383.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00384.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00385.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00387.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00388.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00390.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00392.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00395.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00467.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00472.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00473.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00475.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00477.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00478.java,60,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00492.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00541.java,70,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00542.java,85,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00543.java,76,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00547.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00549.java,71,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00551.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00552.java,70,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00554.java,71,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00555.java,71,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00557.java,69,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00642.java,62,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00643.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00644.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00645.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00651.java,61,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00656.java,58,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00711.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00715.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00719.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00720.java,74,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00721.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00724.java,73,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00725.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00727.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00728.java,60,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00729.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00737.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00800.java,85,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00801.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00802.java,69,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00803.java,65,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00804.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00805.java,78,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00806.java,76,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00807.java,67,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00809.java,72,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00810.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00811.java,84,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00822.java,71,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01046.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01047.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01049.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01050.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01055.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01056.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01057.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01063.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01171.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01172.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01173.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01174.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01177.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01178.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01179.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01181.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01253.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01254.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01257.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01258.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01259.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01260.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01261.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01262.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01263.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01266.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01267.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01268.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01284.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01335.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01337.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01346.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01347.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01349.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01350.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01417.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01418.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01423.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01424.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01426.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01427.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01428.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01429.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01437.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01438.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01505.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01506.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01507.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01509.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01510.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01511.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01512.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01525.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01583.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01584.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01587.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01589.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01590.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01592.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01594.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01596.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01597.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01598.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01657.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01658.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01660.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01662.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01665.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01666.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01667.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01670.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01916.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01919.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01920.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01921.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01922.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01923.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01925.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01926.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01927.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02046.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02047.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02050.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02051.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02054.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02055.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02056.java,56,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02057.java,59,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02123.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02124.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02126.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02127.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02128.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02129.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02130.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02131.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02132.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02133.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02134.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02136.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02145.java,49,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02221.java,57,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02223.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02224.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02225.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02227.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02228.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02230.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02232.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02234.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02241.java,54,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02314.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02315.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02316.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02317.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02321.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02322.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02323.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02324.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02326.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02327.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02328.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02332.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02395.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02396.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02397.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02399.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02400.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02402.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02403.java,51,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02405.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02407.java,50,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02409.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02410.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02480.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02483.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02486.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02487.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02489.java,53,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02493.java,55,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02494.java,52,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02578.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02579.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02580.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02582.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02583.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02584.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02585.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02586.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02587.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02588.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02591.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02592.java,64,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02595.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02597.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02598.java,63,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02600.java,66,79
+F008. Reflected cross-site scripting,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02608.java,63,79
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00012.java,69,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00021.java,60,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00044.java,63,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00630.java,83,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00694.java,64,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00695.java,69,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00947.java,76,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00959.java,78,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01023.java,64,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01241.java,61,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01242.java,61,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01243.java,61,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01326.java,64,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01490.java,60,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01501.java,62,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01568.java,62,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01831.java,76,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01832.java,76,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01902.java,64,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02036.java,68,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02037.java,68,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02196.java,64,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02208.java,66,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02299.java,73,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02305.java,75,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02306.java,75,90
+F017. LDAP injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02472.java,64,90
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00207.java,70,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00442.java,67,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00607.java,76,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01223.java,66,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01224.java,66,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01316.java,59,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01478.java,73,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01561.java,60,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01734.java,73,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01736.java,73,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01892.java,76,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01894.java,76,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01974.java,64,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02100.java,66,643
+F021. XPath Injection,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02189.java,59,643
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00023.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00023.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00066.java,108,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00066.java,109,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00067.java,116,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00067.java,117,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00068.java,108,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00068.java,109,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00078.java,105,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00078.java,106,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00079.java,106,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00079.java,107,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00080.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00080.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00081.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00081.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00082.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00082.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00083.java,106,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00083.java,107,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00084.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00084.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00085.java,106,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00085.java,107,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00086.java,107,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00086.java,108,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00140.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00140.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00160.java,94,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00160.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00161.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00161.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00162.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00162.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00163.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00163.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00164.java,94,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00164.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00165.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00165.java,92,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00166.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00166.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00167.java,93,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00167.java,94,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00168.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00168.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00230.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00230.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00231.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00231.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00232.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00232.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00233.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00233.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00234.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00234.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00235.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00235.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00236.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00236.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00237.java,116,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00237.java,117,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00238.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00238.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00239.java,111,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00239.java,112,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00240.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00240.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00296.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00296.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00297.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00297.java,92,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00298.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00298.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00299.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00299.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00347.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00347.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00368.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00368.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00369.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00369.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00397.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00397.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00398.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00398.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00399.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00399.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00400.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00400.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00401.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00401.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00402.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00402.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00461.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00461.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00482.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00482.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00483.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00483.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00484.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00484.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00485.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00485.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00486.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00486.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00487.java,93,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00487.java,94,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00488.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00488.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00489.java,94,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00489.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00490.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00490.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00560.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00560.java,105,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00561.java,108,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00561.java,109,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00562.java,117,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00562.java,118,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00563.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00563.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00564.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00564.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00652.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00652.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00653.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00653.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00654.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00654.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00702.java,92,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00702.java,93,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00733.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00733.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00734.java,105,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00734.java,106,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00735.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00735.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00817.java,111,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00817.java,112,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00818.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00818.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00819.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00819.java,105,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00898.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00898.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00899.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00899.java,104,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00900.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00900.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00901.java,102,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00901.java,103,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00902.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00902.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00960.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00960.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00971.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00971.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00972.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00972.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00973.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00973.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00974.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00974.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00975.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00975.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00976.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00976.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01058.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01058.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01059.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01059.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01060.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01060.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01119.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01119.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01127.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01127.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01128.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01128.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01129.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01129.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01130.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01130.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01131.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01131.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01132.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01132.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01133.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01133.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01162.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01162.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01163.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01163.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01183.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01183.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01184.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01184.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01271.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01271.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01272.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01272.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01273.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01273.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01274.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01274.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01275.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01275.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01276.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01276.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01277.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01277.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01278.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01278.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01279.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01279.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01354.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01354.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01355.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01355.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01356.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01356.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01357.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01357.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01358.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01358.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01431.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01431.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01432.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01432.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01433.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01433.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01434.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01434.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01435.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01435.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01502.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01502.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01518.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01518.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01519.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01519.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01520.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01520.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01575.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01575.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01602.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01602.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01603.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01603.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01648.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01648.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01675.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01675.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01676.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01676.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01677.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01677.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01678.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01678.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01679.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01679.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01680.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01680.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01681.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01681.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01781.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01781.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01782.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01782.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01783.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01783.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01784.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01784.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01785.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01785.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01786.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01786.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01787.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01787.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01788.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01788.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01842.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01842.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01843.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01843.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01853.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01853.java,101,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01854.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01854.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01855.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01855.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01856.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01856.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01857.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01857.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01858.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01858.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01859.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01859.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01860.java,100,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01860.java,99,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01910.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01910.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01930.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01930.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01931.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01931.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01932.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01932.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01933.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01933.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01934.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01934.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01992.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01992.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01999.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01999.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02000.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02000.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02001.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02001.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02002.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02002.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02003.java,95,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02003.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02004.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02004.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02038.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02038.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02039.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02039.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02040.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02040.java,91,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02060.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02060.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02061.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02061.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02062.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02062.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02063.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02063.java,90,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02117.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02117.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02138.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02138.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02139.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02139.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02140.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02140.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02141.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02141.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02209.java,88,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02209.java,89,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02245.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02245.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02246.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02246.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02337.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02337.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02338.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02338.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02415.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02415.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02416.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02416.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02417.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02417.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02418.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02418.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02419.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02419.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02420.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02420.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02421.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02421.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02422.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02422.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02423.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02423.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02424.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02424.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02425.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02425.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02426.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02426.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02473.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02473.java,87,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02497.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02497.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02498.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02498.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02499.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02499.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02500.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02500.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02501.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02501.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02502.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02502.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02503.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02503.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02504.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02504.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02505.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02505.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02506.java,85,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02506.java,86,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02602.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02602.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02603.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02603.java,98,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02604.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02604.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02605.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02605.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02606.java,96,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02606.java,97,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02700.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02700.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02701.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02701.java,84,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02702.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02702.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02703.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02703.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02704.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02704.java,83,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02705.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02705.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02706.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02706.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02707.java,81,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02707.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02708.java,82,330
+F034. Insecure random number generation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02708.java,83,330
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00087.java,92,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00169.java,86,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00170.java,90,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00241.java,91,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00300.java,82,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00348.java,70,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00403.java,77,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00491.java,80,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00565.java,85,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00566.java,86,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00736.java,80,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00820.java,85,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00821.java,86,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00903.java,90,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00977.java,86,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01061.java,74,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01134.java,83,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01185.java,76,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01186.java,76,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01187.java,76,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01280.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01281.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01282.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01283.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01521.java,70,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01682.java,83,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01683.java,83,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01789.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01861.java,86,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02005.java,83,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02142.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02339.java,83,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02427.java,70,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02507.java,72,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02709.java,69,614
+F042. Insecurely generated cookies,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02710.java,69,614
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00003.java,70,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00005.java,65,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00005.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00019.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00020.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00020.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00029.java,58,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00035.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00046.java,53,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00050.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00050.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00053.java,84,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00053.java,87,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00055.java,78,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00055.java,80,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00056.java,88,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00056.java,90,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00057.java,84,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00057.java,87,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00070.java,74,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00071.java,74,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00073.java,87,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00074.java,76,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00119.java,79,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00119.java,82,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00120.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00120.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00123.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00123.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00124.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00124.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00125.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00125.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00141.java,67,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00141.java,69,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00143.java,78,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00208.java,81,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00208.java,83,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00210.java,78,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00210.java,81,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00223.java,75,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00223.java,77,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00226.java,74,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00227.java,82,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00254.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00254.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00256.java,78,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00256.java,80,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00257.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00257.java,71,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00258.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00258.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00266.java,68,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00266.java,70,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00267.java,64,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00267.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00268.java,64,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00269.java,64,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00272.java,77,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00273.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00274.java,61,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00346.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00346.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00354.java,61,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00355.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00356.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00371.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00372.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00374.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00445.java,79,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00445.java,82,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00446.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00446.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00448.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00449.java,65,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00462.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00462.java,73,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00464.java,59,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00465.java,59,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00521.java,81,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00521.java,84,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00522.java,81,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00522.java,83,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00531.java,75,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00531.java,77,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00532.java,78,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00533.java,75,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00534.java,84,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00536.java,70,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00537.java,65,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00608.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00608.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00609.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00609.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00610.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00610.java,79,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00611.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00611.java,71,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00614.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00614.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00615.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00615.java,71,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00616.java,58,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00617.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00631.java,58,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00631.java,60,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00634.java,62,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00635.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00636.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00637.java,58,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00638.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00684.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00684.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00685.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00685.java,71,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00688.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00688.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00691.java,74,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00691.java,77,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00692.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00692.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00693.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00693.java,70,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00703.java,69,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00703.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00704.java,62,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00704.java,64,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00705.java,60,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00708.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00710.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00779.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00779.java,77,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00781.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00781.java,78,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00789.java,69,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00790.java,65,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00794.java,68,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00796.java,73,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00797.java,72,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00853.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00853.java,65,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00855.java,71,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00855.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00856.java,74,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00856.java,77,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00857.java,80,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00857.java,83,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00859.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00868.java,69,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00868.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00869.java,75,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00869.java,77,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00870.java,51,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00871.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00872.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00875.java,64,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00876.java,60,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00945.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00946.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00961.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00963.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01015.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01015.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01016.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01016.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01017.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01017.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01018.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01018.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01020.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01038.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01041.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01042.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01043.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01044.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01099.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01099.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01102.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01102.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01103.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01103.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01105.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01106.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01107.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01123.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01124.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01148.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01148.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01149.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01149.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01150.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01150.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01165.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01166.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01167.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01168.java,59,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01228.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01228.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01229.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01229.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01230.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01244.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01244.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01246.java,49,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01247.java,49,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01248.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01317.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01317.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01318.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01318.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01320.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01320.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01322.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01322.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01323.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01323.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01325.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01333.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01334.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01398.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01398.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01411.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01414.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01415.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01416.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01480.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01480.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01483.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01483.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01484.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01484.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01486.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01486.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01489.java,56,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01503.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01503.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01504.java,50,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01565.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01565.java,65,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01566.java,58,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01577.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01579.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01580.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01634.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01634.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01637.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01637.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01638.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01638.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01639.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01639.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01641.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01649.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01650.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01651.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01653.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01654.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01740.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01741.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01742.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01757.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01757.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01761.java,49,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01765.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01766.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01822.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01822.java,79,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01823.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01823.java,79,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01829.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01830.java,72,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01844.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01844.java,73,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01845.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01845.java,73,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01846.java,71,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01846.java,73,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01895.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01895.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01897.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01897.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01898.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01898.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01900.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01911.java,59,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01911.java,61,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01978.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01978.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01980.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01981.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01996.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01997.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02017.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02017.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02018.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02018.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02019.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02019.java,69,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02020.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02020.java,68,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02022.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02023.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02042.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02101.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02101.java,61,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02118.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02118.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02121.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02192.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02192.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02193.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02193.java,66,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02194.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02194.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02195.java,64,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02195.java,67,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02211.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02212.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02213.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02217.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02219.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02290.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02290.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02291.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02291.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02292.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02292.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02293.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02293.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02294.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02294.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02295.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02295.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02307.java,68,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02307.java,70,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02308.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02311.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02373.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02373.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02374.java,60,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02374.java,63,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02375.java,56,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02385.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02385.java,57,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02386.java,50,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02387.java,50,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02388.java,50,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02391.java,53,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02392.java,53,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02393.java,53,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02458.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02458.java,65,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02474.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02475.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02476.java,52,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02478.java,55,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02548.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02548.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02549.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02549.java,75,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02550.java,73,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02550.java,76,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02573.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02574.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02575.java,63,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02577.java,66,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02658.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02658.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02660.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02660.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02661.java,59,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02661.java,62,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02663.java,55,310 + 327
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02670.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02670.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02671.java,54,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02671.java,56,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02674.java,49,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02675.java,49,328
+F052. Insecure encryption algorithm,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02677.java,52,328
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00002.java,72,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00011.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00028.java,60,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00040.java,50,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00045.java,63,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00060.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00061.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00062.java,77,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00062.java,77,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00065.java,75,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00065.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00133.java,66,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00215.java,64,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00216.java,70,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00218.java,94,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00219.java,75,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00219.java,75,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00222.java,89,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00262.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00264.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00264.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00359.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00360.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00360.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00362.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00362.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00363.java,61,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00452.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00453.java,70,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00455.java,64,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00456.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00457.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00457.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00459.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00525.java,74,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00526.java,64,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00527.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00528.java,80,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00529.java,69,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00619.java,61,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00623.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00624.java,58,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00624.java,58,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00627.java,61,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00629.java,61,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00629.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00696.java,72,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00697.java,57,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00698.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00700.java,63,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00700.java,63,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00783.java,74,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00783.java,74,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00785.java,75,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00787.java,74,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00788.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00949.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00950.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00952.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00953.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00956.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01025.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01029.java,64,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01032.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01032.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01033.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01033.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01034.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01111.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01112.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01116.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01117.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01155.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01156.java,66,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01157.java,66,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01161.java,61,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01231.java,48,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01232.java,48,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01234.java,48,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01235.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01236.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01238.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01238.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01329.java,64,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01330.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01330.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01403.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01405.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01405.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01408.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01494.java,49,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01495.java,60,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01496.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01497.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01497.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01498.java,60,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01500.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01500.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01571.java,51,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01572.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01572.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01642.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01643.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01645.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01647.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01833.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01835.java,65,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01836.java,76,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01839.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01839.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01840.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01840.java,71,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01904.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01906.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01906.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01907.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01907.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01908.java,57,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01908.java,58,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01983.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01985.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01987.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01988.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01988.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01989.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02027.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02032.java,60,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02034.java,66,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02105.java,48,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02106.java,48,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02109.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02109.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02112.java,54,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02113.java,52,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02113.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02197.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02198.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02199.java,53,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02205.java,59,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02302.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02303.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02303.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02304.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02377.java,49,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02378.java,60,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02383.java,55,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02463.java,51,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02465.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02465.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02466.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02466.java,56,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02469.java,57,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02555.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02556.java,62,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02559.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02560.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02560.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02561.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02562.java,67,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02564.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02564.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02565.java,73,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02567.java,68,22
+F063. Lack of data validation - Path Traversal,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02569.java,68,22
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00004.java,67,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00031.java,55,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00098.java,68,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00251.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00321.java,58,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00324.java,58,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00325.java,58,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00326.java,64,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00327.java,59,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00424.java,55,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00425.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00426.java,57,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00427.java,64,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00508.java,57,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00587.java,70,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00588.java,68,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00668.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00670.java,56,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00671.java,58,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00754.java,59,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00756.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00757.java,73,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00759.java,57,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00833.java,71,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00834.java,69,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00836.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00991.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00994.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00995.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01081.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01082.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01143.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01203.java,56,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01204.java,56,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01206.java,56,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01299.java,49,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01374.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01375.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01376.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01455.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01456.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01457.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01458.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01546.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01547.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01548.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01549.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01550.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01551.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01615.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01616.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01617.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01618.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01619.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01708.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01709.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01710.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01711.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01872.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01874.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01875.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01876.java,66,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01955.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01958.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01960.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02015.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02016.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02084.java,56,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02165.java,49,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02167.java,49,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02261.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02262.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02263.java,54,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02352.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02446.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02448.java,50,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02524.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02525.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02526.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02527.java,52,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02622.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02623.java,63,501
+F063. Lack of data validation - Trust boundary violation,OWASP/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02624.java,63,501

--- a/src/main/java/org/owasp/benchmark/score/BenchmarkScore.java
+++ b/src/main/java/org/owasp/benchmark/score/BenchmarkScore.java
@@ -71,6 +71,7 @@ import org.owasp.benchmark.score.parsers.CoverityReader;
 import org.owasp.benchmark.score.parsers.CrashtestReader;
 import org.owasp.benchmark.score.parsers.FaastReader;
 import org.owasp.benchmark.score.parsers.FindbugsReader;
+import org.owasp.benchmark.score.parsers.FluidAttacks;
 import org.owasp.benchmark.score.parsers.FortifyReader;
 import org.owasp.benchmark.score.parsers.FusionLiteInsightReader;
 import org.owasp.benchmark.score.parsers.HCLReader;
@@ -677,6 +678,8 @@ public class BenchmarkScore {
 				tr = new SeekerReader().parse(fileToParse);
 			} else if ( line1.contains("CWE") && line1.contains("URL") ) {		
 				tr = new CheckmarxIASTReader().parse(fileToParse);
+			} else if ( line1.contains("cwe") && line1.contains("what") ) {
+				tr = new FluidAttacks().parse(fileToParse);
 			} else System.out.println("Error: No matching parser found for CSV file: " + filename);
 		}
 

--- a/src/main/java/org/owasp/benchmark/score/parsers/FluidAttacks.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/FluidAttacks.java
@@ -1,0 +1,122 @@
+/**
+ * OWASP Benchmark Project
+ * <p>
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Benchmark Project For details, please see
+ * <a href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ * <p>
+ * The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * <p>
+ * The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details
+ *
+ * @author https://github.com/kamadorueda
+ * @created 2021
+ */
+
+package org.owasp.benchmark.score.parsers;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FilenameUtils;
+import org.owasp.benchmark.score.BenchmarkScore;
+
+import java.io.File;
+
+public class FluidAttacks extends Reader {
+
+	private static Integer categoryToExpectedCwe(String cwe) {
+		switch (cwe) {
+			case "pathtraver":
+				return 22;
+			case "cmdi":
+				return 78;
+			case "xss":
+				return 79;
+			case "sqli":
+				return 89;
+			case "ldapi":
+				return 90;
+			case "crypto":
+				return 327;
+			case "hash":
+				return 328;
+			case "weakrand":
+				return 330;
+			case "trustbound":
+				return 501;
+			case "securecookie":
+				return 614;
+			case "xpathi":
+				return 643;
+			default:
+				return 0;
+		}
+	}
+
+	private static String cweToCategory(String cwe) {
+		switch (cwe) {
+			case "22":
+				return "pathtraver";
+			case "78":
+				return "cmdi";
+			case "79":
+				return "xss";
+			case "89":
+				return "sqli";
+			case "90":
+				return "ldapi";
+			case "310":
+				return "crypto";
+			case "327":
+				return "crypto";
+			case "328":
+				return "hash";
+			case "330":
+				return "weakrand";
+			case "501":
+				return "trustbound";
+			case "614":
+				return "securecookie";
+			case "643":
+				return "xpathi";
+			default:
+				return "other";
+		}
+	}
+
+	public TestResults parse(File f) throws Exception {
+		TestResults testResults = new TestResults("Fluid Attacks", false, TestResults.ToolType.SAST);
+
+		java.io.Reader inReader = new java.io.FileReader(f);
+		Iterable < CSVRecord > records = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(inReader);
+
+		for (CSVRecord record: records) {
+			TestCaseResult testCaseResult = new TestCaseResult();
+
+			// Columns in the CSV
+			String title = record.get("title");
+			String what = record.get("what");
+			String where = record.get("where");
+			String cwe = record.get("cwe").split(" [+] ")[0];
+
+			// Parse columns into the correct types
+			String category = cweToCategory(cwe);
+			String testCaseName = FilenameUtils.getBaseName(what);
+
+			// Required parameters for the test case to be taken into account
+			testCaseResult.setCategory(category);
+			testCaseResult.setCWE(categoryToExpectedCwe(category));
+			testCaseResult.setNumber(Integer.parseInt(testCaseName.substring(
+				testCaseName.length() - BenchmarkScore.TESTIDLENGTH,
+				testCaseName.length()
+			)));
+			testCaseResult.setTestCaseName(testCaseName);
+			testResults.put(testCaseResult);
+		}
+
+		return testResults;
+	}
+}


### PR DESCRIPTION
- This pull request is regarding issue:
  https://github.com/OWASP/Benchmark/issues/144
- Work done:
  - Add FluidAttacks.java parser for CSV results
  - Update BenchmarkScore to identify when a CSV should
    be parsed with it
  - Add the results as other non-commercial tools do,
    so it serves as base line to generate the scorecard
- Local `mvn compile && ./createScorecards.sh`:
  - ![image](https://user-images.githubusercontent.com/47480384/115056998-1beb5000-9ea9-11eb-9ffb-d300bd0c4d4f.png)
