### PR TITLE
WIP: Read metadata from result files

### DIFF
--- a/src/main/java/org/owasp/benchmark/score/parsers/WapitiJsonReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/WapitiJsonReader.java
@@ -68,6 +68,8 @@ public class WapitiJsonReader extends Reader {
             }
         }
 
+        tr.setToolVersion(readVersion(json));
+
         return tr;
     }
 
@@ -95,5 +97,9 @@ public class WapitiJsonReader extends Reader {
 
     private static int testNumber(String filename) {
         return Integer.parseInt(filename.substring(BenchmarkScore.TESTCASENAME.length() + 1));
+    }
+
+    private static String readVersion(JSONObject json) {
+        return json.getJSONObject("infos").getString("version").substring("Wapiti ".length());
     }
 }


### PR DESCRIPTION
As requested in https://github.com/OWASP/Benchmark/pull/150#issuecomment-853384453

- Read version from Wapiti JSON
- Read duration from Horusec JSON
- WIP: Read version from Horusec JSON*

The export of versions just got merged for Horusec (https://github.com/ZupIT/horusec/pull/474) but they did not release a new version yet. If I read the go files correctly it should just be a string called "version". So let's keep this a WIP PR :-).